### PR TITLE
Helidon: Use JsonBuildFactory, update Helidon to 1.1.2

### DIFF
--- a/frameworks/Java/helidon/pom.xml
+++ b/frameworks/Java/helidon/pom.xml
@@ -26,7 +26,7 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <helidon.version>1.0.3</helidon.version>
+        <helidon.version>1.1.2</helidon.version>
         <!-- Default package. Will be overriden by Maven archetype -->
         <package>io.helidon.examples.quickstart.se</package>
         <mainClass>io.helidon.benchmark.Main</mainClass>

--- a/frameworks/Java/helidon/src/main/java/io/helidon/benchmark/models/World.java
+++ b/frameworks/Java/helidon/src/main/java/io/helidon/benchmark/models/World.java
@@ -1,9 +1,14 @@
 package io.helidon.benchmark.models;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
+import java.util.Collections;
 
 public final class World {
+
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
     public int id;
     public int randomNumber;
 
@@ -13,6 +18,6 @@ public final class World {
     }
 
     public JsonObject toJson() {
-        return Json.createObjectBuilder().add("id", id).add("randomNumber", randomNumber).build();
+        return JSON.createObjectBuilder().add("id", id).add("randomNumber", randomNumber).build();
     }
 }

--- a/frameworks/Java/helidon/src/main/java/io/helidon/benchmark/services/DbService.java
+++ b/frameworks/Java/helidon/src/main/java/io/helidon/benchmark/services/DbService.java
@@ -16,17 +16,21 @@ import io.reactivex.Single;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonStructure;
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class DbService implements Service {
+
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     private final DbRepository repository;
     private JsonWriterFactory jsonWriterFactory;
@@ -89,7 +93,7 @@ public class DbService implements Service {
 
     private JsonArray buildArray(List<JsonObject> jsonObjects) {
         return jsonObjects.stream().reduce(
-                Json.createArrayBuilder(),
+                JSON.createArrayBuilder(),
                 JsonArrayBuilder::add,
                 JsonArrayBuilder::addAll)
                 .build();

--- a/frameworks/Java/helidon/src/main/java/io/helidon/benchmark/services/JsonService.java
+++ b/frameworks/Java/helidon/src/main/java/io/helidon/benchmark/services/JsonService.java
@@ -5,14 +5,17 @@ import io.helidon.webserver.Routing;
 import io.helidon.webserver.Service;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import java.util.Collections;
 
 public class JsonService implements Service {
+
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     @Override
     public void update(Routing.Rules rules) {
         rules.register("/json", JsonSupport.create());
         rules.get("/json",
-                (req, res) -> res.send(Json.createObjectBuilder(Collections.singletonMap("message", "Hello, World!")).build()));
+                (req, res) -> res.send(JSON.createObjectBuilder(Collections.singletonMap("message", "Hello, World!")).build()));
     }
 }


### PR DESCRIPTION
The TechEmpower WebFramework benchmark already has a test for Helidon. But it's using an old Helidon version, and is not using `JsonBuilderFactory`  (it uses the expensive `Json.createObjectBuilder()` convenience method).

I plan on submitting these changes to the TechEmpower/FrameworkBenchmarks repo. This PR is to preview those changes.

Note that there are additional changes we likely want to do (such as using a thread pool in the DbService for example), but the changes in this PR are simple and result in a significant performance improvement. So I'd like to get them in soon.
